### PR TITLE
Fixes dynamic classpath loading.

### DIFF
--- a/atlas.itests.parent/atlas.itests.java.inspect.twitter4j/src/test/java/com/mediadriver/atlas/java/inspect/itests/v2/Twitter4jInspectTest.java
+++ b/atlas.itests.parent/atlas.itests.java.inspect.twitter4j/src/test/java/com/mediadriver/atlas/java/inspect/itests/v2/Twitter4jInspectTest.java
@@ -16,6 +16,7 @@
 package com.mediadriver.atlas.java.inspect.itests.v2;
 
 import com.mediadriver.atlas.java.inspect.v2.ClassInspectionService;
+import com.mediadriver.atlas.java.inspect.v2.InspectionException;
 import com.mediadriver.atlas.java.v2.JavaClass;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -29,28 +30,28 @@ import org.junit.Before;
 public class Twitter4jInspectTest {
 
 	private static final Logger logger = LoggerFactory.getLogger(Twitter4jInspectTest.class);
-	
+
 	private ClassInspectionService classInspectionService = null;
-	
+
 	@Before
 	public void setUp() {
 		classInspectionService = new ClassInspectionService();
 	}
-	
+
 	@After
 	public void tearDown() {
 		classInspectionService = null;
 	}
-	
+
 	@Test
-	public void testInspectTwitter4jStatus() {
+	public void testInspectTwitter4jStatus() throws InspectionException {
 		JavaClass j = classInspectionService.inspectClass("twitter4j.Status");
 		assertNotNull(j);
 		logger.debug("Hello");
 	}
-	
+
 	@Test
-	public void testInspectTwitter4jStatusJSONImpl() {
+	public void testInspectTwitter4jStatusJSONImpl() throws InspectionException {
 		JavaClass j = classInspectionService.inspectClass("twitter4j.StatusJSONImpl");
 		assertNotNull(j);
 		logger.debug("Hello");

--- a/atlas.java.parent/atlas.java.inspect/pom.xml
+++ b/atlas.java.parent/atlas.java.inspect/pom.xml
@@ -47,10 +47,6 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.xeustechnologies</groupId>
-			<artifactId>jcl-core</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 		</dependency>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -152,24 +152,7 @@
       <artifactId>resteasy-spring-boot-starter</artifactId>
       <version>${resteasy-spring-boot-starter.version}</version>
     </dependency>
-
-    <!-- for now adding all connectors -->
-    <dependency>
-      <groupId>com.redhat.ipaas</groupId>
-      <artifactId>twitter-mention-connector</artifactId>
-      <version>${ipaas.connector.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.redhat.ipaas</groupId>
-      <artifactId>salesforce-upsert-contact-connector</artifactId>
-      <version>${ipaas.connector.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.redhat.ipaas</groupId>
-      <artifactId>timer-connector</artifactId>
-      <version>${ipaas.connector.version}</version>
-    </dependency>
-
+    
   </dependencies>
 
   <repositories>


### PR DESCRIPTION
- Drops need to include connectors in the runtime jar.
- JVM’s URLClassLoader is good enough, don’t really need the icl-core dep.  dropping that too.
- Avoid using Class.forName() since that’s using the wrong class loader and can’t be unloaded.
- Use the system classloader as the parent CL for introspection since that will avoid class loading conflicts in a Spring Boot runtime.